### PR TITLE
KinesisFirehouseCIDR into Redshift Template

### DIFF
--- a/templates/redshift.template
+++ b/templates/redshift.template
@@ -83,6 +83,9 @@
             "us-west-2": {
                 "KinesisFirehoseCIDR": "52.89.255.224/27"
             }
+            "ap-southeast-2": {
+                "KinesisFirehoseCIDR": "13.210.67.224/27"
+            }
         }
     },
     "Conditions": {


### PR DESCRIPTION
Templates fails when deployed in Australia Southeast Region - Inclusion of KinesisFirehoseCIDR in template.